### PR TITLE
Bugfix missing `=` 

### DIFF
--- a/MessageHandling.py
+++ b/MessageHandling.py
@@ -71,7 +71,7 @@ battery_charging_status = {
 }
 
 # 5 bit command. 7-15
-vdo_command: {
+vdo_command= {
     0b00000: 'Reserved',
     0b00001: 'Discover Identity',
     0b00010: 'Discover SVIDs',


### PR DESCRIPTION
Hello,

Thank you so much for starting this; definitely making some debugging easier already.

Ran into the decoder crashing on some of my captures due to `vdo_command` not being defined that this fix is for.

Also ran into `decode_request_data_object` crashing due to missing second arg for `pdo_type` but for now I've hard coded that to get the rest of the analyzer to run. (Not in this PR)

Happy to send some random sample captures if they would be of interest (Not sure of your preferred method of sending them).

So far signal integrity seems fine (Saleae pro 16 at 1.2v trigger). Though definitely running into not defined commands I need to look into adding :) 

❤️ 
- Ralim